### PR TITLE
ref: simplify sendiOSToComposer method and clean up iOS command handlers

### DIFF
--- a/src/ios/commands/index.ts
+++ b/src/ios/commands/index.ts
@@ -36,10 +36,7 @@ export class iOSCommandHandlers {
         "Capturing iOS Screenshot",
         async () => {
           const screenshot = await this.iOSSimulatorMonitor.captureScreenshot();
-          await this.composerIntegration.sendiOSToComposer(
-            screenshot,
-            undefined
-          );
+          await this.composerIntegration.sendiOSToComposer(screenshot);
         }
       );
       this.toastService.showInfo("iOS screenshot sent successfully");
@@ -60,10 +57,7 @@ export class iOSCommandHandlers {
         "Capturing iOS Screenshot",
         async () => {
           const screenshot = await this.iOSSimulatorMonitor.captureScreenshot();
-          await this.composerIntegration.sendiOSToComposer(
-            screenshot,
-            undefined
-          );
+          await this.composerIntegration.sendiOSToComposer(screenshot);
         }
       );
       this.toastService.showInfo("iOS screenshot captured successfully");

--- a/src/ios/simulator.ts
+++ b/src/ios/simulator.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { EventEmitter } from "events";
-import { exec, spawn } from "child_process";
+import { exec } from "child_process";
 import { promisify } from "util";
 import * as path from "path";
 import * as fs from "fs/promises";

--- a/src/shared/composer/integration.ts
+++ b/src/shared/composer/integration.ts
@@ -125,10 +125,7 @@ export class ComposerIntegration {
     }
   }
 
-  public async sendiOSToComposer(
-    screenshot?: Buffer,
-    logs?: undefined
-  ): Promise<void> {
+  public async sendiOSToComposer(screenshot?: Buffer): Promise<void> {
     const maxRetries = 2;
     let imageAttempt = 0;
     let imageSuccess = false;


### PR DESCRIPTION
This pull request includes several changes to the iOS command handling and simulator integration. The most important changes involve simplifying method calls and cleaning up imports.

Simplification of method calls:

* [`src/ios/commands/index.ts`](diffhunk://#diff-0df564994193d4171afd8f3a1e940d676987872089ab93cbae1cbb38d6c0283aL39-R39): Modified the `sendiOSToComposer` method calls to remove the unnecessary `undefined` parameter when sending screenshots. [[1]](diffhunk://#diff-0df564994193d4171afd8f3a1e940d676987872089ab93cbae1cbb38d6c0283aL39-R39) [[2]](diffhunk://#diff-0df564994193d4171afd8f3a1e940d676987872089ab93cbae1cbb38d6c0283aL63-R60)
* [`src/shared/composer/integration.ts`](diffhunk://#diff-29e045709d67902c3b45fd822c0edfc51c55760ed525f952f5eb92e3b7ec85a9L128-R128): Updated the `sendiOSToComposer` method to remove the optional `logs` parameter, simplifying the method signature.

Cleanup of imports:

* [`src/ios/simulator.ts`](diffhunk://#diff-9b7c66ece591bb3cf07adab3f124fe81035d343aba54f17039aa3363552c335bL3-R3): Removed the unused `spawn` import from the `child_process` module.